### PR TITLE
Remove resizing

### DIFF
--- a/internal/tiny.go
+++ b/internal/tiny.go
@@ -36,7 +36,7 @@ func compress(source string) (output string) {
 
 func convert(source string) (output []byte) {
 	client := &http.Client{}
-	jsonBody := []byte(`{"resize":{"method":"scale","width":1000},"convert":{"type":"image/webp"}}`)
+	jsonBody := []byte(`{"convert":{"type":"image/webp"}}`)
 	bodyReader := bytes.NewReader(jsonBody)
 	req, _ := http.NewRequest("POST", source, bodyReader)
 	req.SetBasicAuth("api", apiKey)


### PR DESCRIPTION
It doesn't really save that much space once it's compressed, and it does make things look worse.

Could add it as an option again in the future if we want, but I don't think it was a good idea in the first place.